### PR TITLE
rcar-gen3: images: core-image-minimal: Add a wic variation for Docker

### DIFF
--- a/meta-rcar-gen3/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rcar-gen3/recipes-core/images/core-image-minimal.bbappend
@@ -1,6 +1,8 @@
 require ${@"recipes-core/images/rcar-gen3-bsp-release.inc" if "rcar-gen3" in d.getVar("OVERRIDES") else ""}
 
-WKS_FILE="rcar-dualpart-noloader_ext4.wks"
+WKS_FILE = "${@bb.utils.contains('DISTRO_FEATURES', 'docker', \
+    'rcar-dualpart-noloader_ext4_8gb.wks', \
+    'rcar-dualpart-noloader_ext4.wks', d)}"
 
 IMAGE_INSTALL_append = " kernel-modules"
 

--- a/meta-rcar-gen3/wic/rcar-dualpart-noloader_ext4_8gb.wks
+++ b/meta-rcar-gen3/wic/rcar-dualpart-noloader_ext4_8gb.wks
@@ -1,0 +1,9 @@
+# short-description: Single partition rootfs with UUID and no bootloader
+# long-description: Creates a partitioned image with a single partition in
+# use and does not contain a bootloader.
+
+# / is 8GB
+part / --source rootfs --use-uuid --fstype=ext4 --label root --align 4096 --size 8192
+# /data is 4GB
+part /data --use-uuid --fstype=ext4 --label data --align 4096 --active --size 4096
+


### PR DESCRIPTION
Current wks file for core-image-minimal generates minimum root partition.
But it is NOT enough to use docker with default settings.

Signed-off-by: Tomohiro Komagata <tomohiro.komagata.aj@gmail.com>